### PR TITLE
Localization pt-BR.json

### DIFF
--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1,0 +1,53 @@
+{
+    "LIMITS": {
+        "label": "Alcance Limite",
+        "FIELDS": {
+            "sight": {
+                "label": "Visão",
+                "hint": "Configura os modos de detecção que este limite se aplica."
+            },
+            "light": {
+                "label": "Luz",
+                "hint": "Configura se este limite se aplica às fontes de luz."
+            },
+            "darkness": {
+                "label": "Escuridão",
+                "hint": "Configura se este limite se aplica às fontes de escuridão."
+            },
+            "sound": {
+                "label": "Som",
+                "hint": "Configura se este limite se aplica às fontes de som."
+            },
+            "range": {
+                "label": "Alcance",
+                "hint": "Configura o alcance deste limite."
+            },
+            "mode": {
+                "label": "Modo",
+                "hint": "Configura como o alcance deste limite afeta o alcance efetivo."
+            },
+            "priority": {
+                "label": "Prioridade",
+                "hint": "Configura a ordem em que os limites são aplicados para determinar o alcance efetivo."
+            }
+        },
+        "MODES": {
+            "STACK": {
+                "label": "Pilha",
+                "hint": "O alcance efetivo é reduzido ainda mais por este limite."
+            },
+            "UPGRADE": {
+                "label": "Melhorar",
+                "hint": "O alcance efetivo é aumentado até o alcance deste limite."
+            },
+            "DOWNGRADE": {
+                "label": "Piorar",
+                "hint": "O alcance efetivo é diminuído até o alcance deste limite."
+            },
+            "OVERRIDE": {
+                "label": "Substituir",
+                "hint": "O alcance efetivo é substituído pelo alcance deste limite."
+            }
+        }
+    }
+}

--- a/module.json
+++ b/module.json
@@ -29,6 +29,11 @@
             "lang": "en",
             "name": "English",
             "path": "lang/en.json"
+        },
+        {
+            "lang": "pt-BR",
+            "name": "Portuguese (Brazil)",
+            "path": "lang/pt-BR.json"
         }
     ],
     "url": "https://github.com/dev7355608/limits",


### PR DESCRIPTION
A translation to Brazilian Portuguese. It has to be added as follows in module.json:
```js
        {
            "lang": "pt-BR",
            "name": "Português (Brasil)",
            "path": "lang/pt-BR.json"
        }
```